### PR TITLE
Correcting typo (#93)

### DIFF
--- a/Arduino_package/hardware/libraries/FatfsSDIO/src/FatFs_SD.cpp
+++ b/Arduino_package/hardware/libraries/FatfsSDIO/src/FatFs_SD.cpp
@@ -54,7 +54,7 @@ int FatFsSD::begin() {
 
         drv_num = FATFS_RegisterDiskDriver(&SD_disk_Driver);
         if (drv_num < 0) {
-            printf("Rigester disk driver to FATFS fail.\n");
+            printf("Register disk driver to FATFS fail.\n");
             ret = FR_DISK_ERR;
             break;
         }


### PR DESCRIPTION
* TFL magic wand example update

For TensorFlow Lite - magic wand example, LED pins are define according to the boards (AMB21/22, AMB23, BW16) used. For AMB21/22, pin 12 and 13 are define for LED. For AMB23 and BW16, onboard LED will be used,  the LED pin numbers are changed to "LED_G" and "LED_B".

* Typo error in code

Spelling error found in : printf("Rigester disk driver to FATFS fail.\n");
Replaced as: printf("Register disk driver to FATFS fail.\n");